### PR TITLE
Add python3 compatibility with working tests.

### DIFF
--- a/pgcrypto/base.py
+++ b/pgcrypto/base.py
@@ -2,9 +2,9 @@ __version_info__ = (1, 2, 0)
 __version__ = '.'.join(str(i) for i in __version_info__)
 
 import base64
-import datetime
-import decimal
 import struct
+
+from django.utils import six
 
 CRC24_INIT = 0xB704CE
 CRC24_POLY = 0x1864CFB
@@ -110,7 +110,7 @@ def pad(text, block_size, zero=False):
     by pgcrypto. See http://www.di-mgt.com.au/cryptopad.html for more information.
     """
     num = block_size - (len(text) % block_size)
-    ch = '\0' if zero else chr(num)
+    ch = b'\0' if zero else six.b(chr(num))
     return text + (ch * num)
 
 def aes_pad_key(key):

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,15 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pycrypto>=2.6',
+        'Django>=1.6',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Database',
     ]
 )

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -1,11 +1,15 @@
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
 import pgcrypto
 
+
+@python_2_unicode_compatible
 class Employee (models.Model):
     name = models.CharField(max_length=200)
     ssn = pgcrypto.EncryptedCharField()
     salary = pgcrypto.EncryptedDecimalField()
     date_hired = pgcrypto.EncryptedDateField(cipher='Blowfish', key='datekey')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/tests/core/tests.py
+++ b/tests/core/tests.py
@@ -28,7 +28,7 @@ class CryptoTests (unittest.TestCase):
 
     def test_encrypt(self):
         c = Blowfish.new('pass', Blowfish.MODE_CBC, self.iv_blowfish)
-        self.assertEqual(c.encrypt(pad('sensitive information', c.block_size)), self.encrypt_bf)
+        self.assertEqual(c.encrypt(pad(b'sensitive information', c.block_size)), self.encrypt_bf)
 
     def test_decrypt(self):
         c = Blowfish.new('pass', Blowfish.MODE_CBC, self.iv_blowfish)
@@ -39,11 +39,11 @@ class CryptoTests (unittest.TestCase):
         self.assertEqual(dearmor(a), self.encrypt_bf)
 
     def test_aes(self):
-        c = AES.new(aes_pad_key('pass'), AES.MODE_CBC, self.iv_aes)
-        self.assertEqual(c.encrypt(pad('sensitive information', c.block_size)), self.encrypt_aes)
+        c = AES.new(aes_pad_key(b'pass'), AES.MODE_CBC, self.iv_aes)
+        self.assertEqual(c.encrypt(pad(b'sensitive information', c.block_size)), self.encrypt_aes)
 
     def test_aes_pad(self):
-        c = AES.new(aes_pad_key('secret'), AES.MODE_CBC, self.iv_aes)
+        c = AES.new(aes_pad_key(b'secret'), AES.MODE_CBC, self.iv_aes)
         self.assertEqual(unpad(c.decrypt(self.encrypt_aes_padded), c.block_size), b'xxxxxxxxxxxxxxxx')
 
 class FieldTests (TestCase):
@@ -56,7 +56,7 @@ class FieldTests (TestCase):
 
     def test_query(self):
         fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'employees.json')
-        for obj in json.load(open(fixture_path, 'rb')):
+        for obj in json.load(open(fixture_path, 'r')):
             if obj['model'] == 'core.employee':
                 e = Employee.objects.get(ssn=obj['fields']['ssn'])
                 self.assertEqual(e.pk, int(obj['pk']))


### PR DESCRIPTION
So I looked into adding Python 3 support. Tests still work, but I had to enforce arguments going into the padding functions to be binary/bytes.

This is a theoretical port ("made the tests work"), but if people could look whether or not it works for them in their projects, that would be great :-)
