### PR TITLE
Avoid importing the whole project

### DIFF
--- a/pgcrypto/__init__.py
+++ b/pgcrypto/__init__.py
@@ -12,9 +12,4 @@
 #
 # See http://www.ietf.org/rfc/rfc2440.txt for ASCII Armor specs.
 
-from .base import __version__, __version_info__, armor, dearmor, pad, unpad, aes_pad_key
-
-try:
-    from .fields import *
-except ImportError:
-    pass
+VERSION = '1.2.1'

--- a/pgcrypto/base.py
+++ b/pgcrypto/base.py
@@ -1,6 +1,3 @@
-__version_info__ = (1, 2, 0)
-__version__ = '.'.join(str(i) for i in __version_info__)
-
 import base64
 import struct
 
@@ -37,7 +34,7 @@ def armor(data, versioned=True):
     # The 24-bit CRC should be in big-endian, strip off the first byte (it's already masked in crc24).
     crc = base64.b64encode(struct.pack('>L', crc24(data))[1:])
     return template % {
-        'headers': 'Version: django-pgcrypto %s\n\n' % __version__ if versioned else '',
+        'headers': 'Version: django-pgcrypto {}\n\n'.format(VERSION),
         'body': body.decode('ascii'),
         'crc': crc.decode('ascii'),
     }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import pgcrypto
 
 setup(
     name='django-pgcrypto',
-    version=pgcrypto.__version__,
+    version=pgcrypto.VERSION,
     description='Python and Django utilities for encrypted fields using pgcrypto.',
     author='Dan Watson',
     author_email='dcwatson@gmail.com',


### PR DESCRIPTION
When trying to install the project with pip we get an error as `setup.py` is calling `pgcrypto.__init__.py` which import both `base.py` (for the version) and `fields.py` for shortcuts.
Since `fields.py` is importing django this is producing a `django.core.exceptions.ImproperlyConfigured`.

I think it would be better to remove `from .fields import *` which is wrapped in `try..except` which ignore the error. And to remove in the `__init__` from base as they are reimported in `fields.py`
