### PR TITLE
Allow cipher_key to be text type or bytes type.

### DIFF
--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -21,7 +21,9 @@ class BaseEncryptedField (models.Field):
         self.cipher_key = kwargs.pop('key', getattr(settings, 'PGCRYPTO_DEFAULT_KEY', ''))
         self.charset = 'utf-8'
         if self.cipher_name == 'AES':
-            self.cipher_key = aes_pad_key(self.cipher_key.encode(self.charset))
+            if isinstance(self.cipher_key, six.text_type):
+                self.cipher_key = self.cipher_key.encode(self.charset)
+            self.cipher_key = aes_pad_key(self.cipher_key)
         mod = __import__('Crypto.Cipher', globals(), locals(), [self.cipher_name], 0)
         self.cipher_class = getattr(mod, self.cipher_name)
         self.check_armor = kwargs.pop('check_armor', True)


### PR DESCRIPTION
Fixes #13

Something about the load order during django migration commands causes Field classes to be initialized with the cipher key already converted to bytes and padded.

This PR changes the init method on BaseField so that it won't try to convert a bytes object to bytes. 

This is something of a quick-fix, since I didn't dig into django to determine what about the way the classes are loaded causes the init method to get the cipher as bytes in the first place, but I figured that regardless it's better to be permissive with what init accepts. 