### PR TITLE
removed Blowfish

### DIFF
--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -21,8 +21,6 @@ class BaseEncryptedField(models.Field):
     def __init__(self, *args, **kwargs):
         self.cipher_name = kwargs.pop("cipher", getattr(settings, "PGCRYPTO_DEFAULT_CIPHER", "aes")).lower()
         # Backwards-compatibility.
-        if self.cipher_name == "blowfish":
-            self.cipher_name = "bf"
         if self.cipher_name not in ("aes", "bf"):
             raise ValueError("Cipher must be 'aes' or 'bf'.")
         self.cipher_key = kwargs.pop("key", getattr(settings, "PGCRYPTO_DEFAULT_KEY", settings.SECRET_KEY))


### PR DESCRIPTION
I had this error: /usr/local/lib/python3.10/site - packages/pgcrypto/fields.py: 58: CryptographyDeprecationWarning: Blowfish has been deprecated.  I had to remove the Blowfish in order for this error to disappear.