### PR TITLE
Drop Blowfish algorithm

### DIFF
--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -20,11 +20,8 @@ class BaseEncryptedField(models.Field):
 
     def __init__(self, *args, **kwargs):
         self.cipher_name = kwargs.pop("cipher", getattr(settings, "PGCRYPTO_DEFAULT_CIPHER", "aes")).lower()
-        # Backwards-compatibility.
-        if self.cipher_name == "blowfish":
-            self.cipher_name = "bf"
-        if self.cipher_name not in ("aes", "bf"):
-            raise ValueError("Cipher must be 'aes' or 'bf'.")
+        if self.cipher_name not in ("aes", ):
+            raise ValueError("Cipher must be 'aes'. cipher={}".format(self.cipher_name))
         self.cipher_key = kwargs.pop("key", getattr(settings, "PGCRYPTO_DEFAULT_KEY", settings.SECRET_KEY))
         self.charset = kwargs.pop("charset", "utf-8")
         if isinstance(self.cipher_key, str):
@@ -55,7 +52,7 @@ class BaseEncryptedField(models.Field):
 
     @property
     def algorithm(self):
-        return {"aes": algorithms.AES, "bf": algorithms.Blowfish}[self.cipher_name]
+        return {"aes": algorithms.AES}[self.cipher_name]
 
     @property
     def block_size(self):

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -8,7 +8,7 @@ class Employee(models.Model):
     age = pgcrypto.EncryptedIntegerField(default=42)
     ssn = pgcrypto.EncryptedCharField("SSN", versioned=True, blank=True)
     salary = pgcrypto.EncryptedDecimalField()
-    date_hired = pgcrypto.EncryptedDateField(cipher="bf", key="datekey", auto_now_add=True)
+    date_hired = pgcrypto.EncryptedDateField(cipher="aes", key="datekey", auto_now_add=True)
     email = pgcrypto.EncryptedEmailField(unique=True, null=True)
     date_modified = pgcrypto.EncryptedDateTimeField(auto_now=True)
 

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -4,7 +4,7 @@ import json
 import os
 import unittest
 
-from cryptography.hazmat.primitives.ciphers.algorithms import AES, Blowfish
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -20,11 +20,6 @@ from .models import Employee
 
 class CryptoTests(unittest.TestCase):
     def setUp(self):
-        # This is the expected Blowfish-encrypted value, according to the following pgcrypto call:
-        #     select encrypt('sensitive information', 'pass', 'bf');
-        self.encrypt_bf = b"x\364r\225\356WH\347\240\205\211a\223I{~\233\034\347\217/f\035\005"
-        # The basic "encrypt" call assumes an all-NUL IV of the appropriate block size.
-        self.iv_blowfish = b"\0" * Blowfish.block_size
         # This is the expected AES-encrypted value, according to the following pgcrypto call:
         #     select encrypt('sensitive information', 'pass', 'aes');
         self.encrypt_aes = b"\263r\011\033]Q1\220\340\247\317Y,\321q\224KmuHf>Z\011M\032\316\376&z\330\344"
@@ -39,16 +34,16 @@ class CryptoTests(unittest.TestCase):
         )
 
     def test_encrypt(self):
-        f = BaseEncryptedField(cipher="bf", key=b"pass")
-        self.assertEqual(f.encrypt(pad(b"sensitive information", f.block_size)), self.encrypt_bf)
+        f = BaseEncryptedField(cipher="aes", key=b"pass")
+        self.assertEqual(f.encrypt(pad(b"sensitive information", f.block_size)), self.encrypt_aes)
 
     def test_decrypt(self):
-        f = BaseEncryptedField(cipher="bf", key=b"pass")
-        self.assertEqual(unpad(f.decrypt(self.encrypt_bf), f.block_size), b"sensitive information")
+        f = BaseEncryptedField(cipher="aes", key=b"pass")
+        self.assertEqual(unpad(f.decrypt(self.encrypt_aes), f.block_size), b"sensitive information")
 
     def test_armor_dearmor(self):
-        a = armor(self.encrypt_bf)
-        self.assertEqual(dearmor(a), self.encrypt_bf)
+        a = armor(self.encrypt_aes)
+        self.assertEqual(dearmor(a), self.encrypt_aes)
 
     def test_aes(self):
         f = BaseEncryptedField(cipher="aes", key=b"pass")


### PR DESCRIPTION
as its marked as deprecated on [cryptography==37.0.0](https://cryptography.io/en/latest/changelog/#v37-0-0)
```
/opt/venv/lib/python3.9/site-packages/pgcrypto/fields.py:58: CryptographyDeprecationWarning: Blowfish has been deprecated
  return {"aes": algorithms.AES, "bf": algorithms.Blowfish}[self.cipher_name]
```

May fix https://github.com/dcwatson/django-pgcrypto/issues/32
