### PR TITLE
Fix issue with non-string values in `get_db_prep_save` for a `bulk_update` operation

### DIFF
--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -105,7 +105,13 @@ class BaseEncryptedField(models.Field):
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
-    def get_db_prep_value(self, value, connection, is_prepared=False):
+    def get_db_prep_save(self, value, connection):
+
+        if hasattr(value, "as_sql"):
+            # If the value is a query expression do not encrypt it, it will circle back to this function to
+            # encrypt the value in the Val() expression within the query.
+            return value
+
         if value and not self.is_encrypted(value):
             # If we have a value and it's not encrypted, do the following before storing
             # in the database:

--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -105,7 +105,7 @@ class BaseEncryptedField(models.Field):
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
-    def get_db_prep_save(self, value, connection):
+    def get_db_prep_value(self, value, connection, is_prepared=False):
         if value and not self.is_encrypted(value):
             # If we have a value and it's not encrypted, do the following before storing
             # in the database:

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -213,3 +213,17 @@ class FieldTests(TestCase):
         with self.assertRaises(UnicodeDecodeError):
             f = BaseEncryptedField(key="badkeyisaverybadkey")
             f.to_python(raw_ssn)
+
+    def test_bulk_update(self):
+
+        employees_to_update = Employee.objects.filter(ssn__in=["999-05-6728", "666-27-9811"])
+        for employee in employees_to_update:
+            employee.salary += 10000
+
+        Employee.objects.bulk_update(employees_to_update, ["salary"])
+
+        updated_employee_1 = Employee.objects.get(ssn="999-05-6728")
+        updated_employee_2 = Employee.objects.get(ssn="666-27-9811")
+
+        self.assertEqual(updated_employee_1.salary, decimal.Decimal("62000.00"))
+        self.assertEqual(updated_employee_2.salary, decimal.Decimal("85248.77"))


### PR DESCRIPTION
This pull request addresses an issue in the `BaseEncryptedField` class where objects with an as_sql method are not checked and are incorrectly processed in the `get_db_prep_save` method during a `bulk_update` operation.

Problem

During a `bulk_update`, the `get_db_prep_save` method is passed query expressions. However, the method incorrectly attempts to encrypt these query expressions directly, leading to exponential growth in the data size within the database during repeated `bulk_update` operations. This behavior occurs because query expressions, like `Cast` `<django.db.models.functions.comparison.Cast>`, are not handled correctly within the encryption process.

Solution

The new implementation checks if the value is a query expression (i.e., it has an `as_sql()` method), and skips encryption in such cases. This ensures that query expressions are handled properly without being mistakenly converted into `bytes`.

The encryption still occurs for standard field values (e.g., `Decimal`, `Integer`, `String`) that require encryption, while query expressions are correctly processed by the database.

Changes

- Updated `get_db_prep_save`:
The `get_db_prep_save` method now checks if the value is a query expression (`as_sql()`) and returns the value without encryption if it is. This allows SQL expressions to be processed properly during database operations, and ensures encryption occurs later for the actual values.
- New Test for `bulk_update`:
A new test has been added to verify the correct behavior of `bulk_update` operations. The test ensures that the `get_db_prep_save` method processes encrypted fields correctly while handling SQL expressions appropriately during `bulk_update`.

Cheers,
Jeroen Weustink
